### PR TITLE
FIX: Eclipse does not show errors

### DIFF
--- a/com.avaje.ebean.eclipse.enhancer/META-INF/MANIFEST.MF
+++ b/com.avaje.ebean.eclipse.enhancer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: com.avaje.ebean.eclipse.enhancer;singleton:=true
-Bundle-Version: 8.1.2
+Bundle-Version: 8.1.3.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: com.avaje.ebean.eclipse.internal.enhancer.EnhancerPlugin
 Export-Package: com.avaje.ebean.eclipse.internal.enhancer;x-internal:=true,

--- a/com.avaje.ebean.eclipse.enhancer/pom.xml
+++ b/com.avaje.ebean.eclipse.enhancer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.avaje.ebean</groupId>
     <artifactId>ebean-eclipse</artifactId>
-    <version>8.1.2</version>
+    <version>8.1.3-SNAPSHOT</version>
     <relativePath>../</relativePath>    
   </parent>
 

--- a/com.avaje.ebean.eclipse.enhancer/src/com/avaje/ebean/eclipse/internal/enhancer/builder/EnhanceBuilder.java
+++ b/com.avaje.ebean.eclipse.enhancer/src/com/avaje/ebean/eclipse/internal/enhancer/builder/EnhanceBuilder.java
@@ -130,9 +130,17 @@ public final class EnhanceBuilder extends IncrementalProjectBuilder {
       }
       // create Markers for all errors in SourceFile
       
-      if (sourceFile != null) {
-        sourceFile.deleteMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);   
-      }
+//      if (sourceFile != null) {
+//        for (IMarker marker : sourceFile.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)) {
+//          // Quick fix, delete only our markers.
+//          // I'm not sure if this is really required
+//          if (marker.getAttribute(IMarker.MESSAGE) != null 
+//              && marker.getAttribute(IMarker.MESSAGE).toString().startsWith("Error during enhancement")) {
+//                  marker.delete();
+//          }
+//            
+//        }
+//      }
       for(List<Throwable> list : entityBeanTransformer.getUnexpectedExceptions().values() ) {
         for (Throwable t : list) {
           createErrorMarker(sourceFile == null ? project :sourceFile, t);

--- a/com.avaje.ebean.eclipse.feature/feature.xml
+++ b/com.avaje.ebean.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaje.ebean.eclipse"
       label="%plugin.name"
-      version="8.1.2"
+      version="8.1.3.qualifier"
       provider-name="%plugin.provider">
 
    <description url="">

--- a/com.avaje.ebean.eclipse.feature/pom.xml
+++ b/com.avaje.ebean.eclipse.feature/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.avaje.ebean</groupId>
     <artifactId>ebean-eclipse</artifactId>
-    <version>8.1.2</version>
+    <version>8.1.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.avaje.ebean</groupId>
   <artifactId>ebean-eclipse</artifactId>
-  <version>8.1.2</version>
+  <version>8.1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/update.site/category.xml
+++ b/update.site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaje.ebean.eclipse_8.1.2.qualifier.jar" id="com.avaje.ebean.eclipse" version="8.1.2.qualifier">
+   <feature url="features/com.avaje.ebean.eclipse_8.1.3.qualifier.jar" id="com.avaje.ebean.eclipse" version="8.1.3.qualifier">
       <category name="com.avaje.ebean.eclipse.released"/>
    </feature>
    <category-def name="com.avaje.ebean.eclipse.released" label="Released">

--- a/update.site/pom.xml
+++ b/update.site/pom.xml
@@ -9,12 +9,12 @@
   <parent>
     <groupId>org.avaje.ebean</groupId>
     <artifactId>ebean-eclipse</artifactId>
-    <version>8.1.2</version>
+    <version>8.1.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>update.site</artifactId>  
   <packaging>eclipse-repository</packaging>
-  <version>8.1.2</version>
+  <version>8.1.3-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
Hello Rob,

I've found a small bug in my extension. I have followed this tutorial: https://wiki.eclipse.org/FAQ_How_do_I_create_problem_markers_for_my_compiler%3F
but deleting ALL markers seems to be wrong, because it will delete ALL markers (also errors from other plugins)

I do not know how can I delete only my markers, also I do not know if it is neccessary at all to delete them. (so I commented out that little hack completely)

BTW: How do you bump the version numbers? Is there a neat 'mvn release' command or has this be done by manually editing the files?

cheers
Roland

